### PR TITLE
Do not flush data to serial until enter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,8 @@
   <label for="rtscts">Hardware flow control</label>
   <input id="echo" type="checkbox">
   <label for="echo">Local echo</label>
+  <input id="enter_flush" type="checkbox">
+  <label for="enter_flush">Flush on enter</label>
 </p>
 <div id="terminal"></div>
 </body>


### PR DESCRIPTION
This enables easier testing of serial interfaces that do not act on single character input.

for example the following accumulate code now works; 
```
while (Serial.available() > 0) {
   input = input + char(Serial.read());
}
```
