### PR TITLE
Add option to use Web Serial API polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/w3c-web-serial": "^1.0.1",
+        "web-serial-polyfill": "^1.0.12",
         "xterm": "^4.11.0",
         "xterm-addon-fit": "^0.5.0"
       },
@@ -9705,6 +9706,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/web-serial-polyfill": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/web-serial-polyfill/-/web-serial-polyfill-1.0.12.tgz",
+      "integrity": "sha512-REcPAAAdCB8UxEybM9B5S3ZcIkVMw8yCqt2UINQjfwYyt+vfQw/nFljYgawQmsdaG7ucgggmCzyx6HqnKeohrQ=="
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -18485,6 +18491,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "web-serial-polyfill": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/web-serial-polyfill/-/web-serial-polyfill-1.0.12.tgz",
+      "integrity": "sha512-REcPAAAdCB8UxEybM9B5S3ZcIkVMw8yCqt2UINQjfwYyt+vfQw/nFljYgawQmsdaG7ucgggmCzyx6HqnKeohrQ=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@types/w3c-web-serial": "^1.0.1",
+    "web-serial-polyfill": "^1.0.12",
     "xterm": "^4.11.0",
     "xterm-addon-fit": "^0.5.0"
   },


### PR DESCRIPTION
When the page is loaded with the ?polyfill=1 query parameter
https://github.com/google/web-serial-polyfill will be used to provide
an implementation of the Web Serial API instead of calling into the
browser's implementation.

Fixes #1.