### PR TITLE
Add option to enable EOL conversion

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -66,6 +66,8 @@
   <label for="echo">Local echo</label>
   <input id="enter_flush" type="checkbox">
   <label for="enter_flush">Flush on enter</label>
+  <input id="convert_eol" type="checkbox">
+  <label for="convert_eol">Convert EOL</label>
   <button id="download">Download output</button>
 </div>
 <div id="terminal"></div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,6 +348,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   flushOnEnterCheckbox =
       document.getElementById('enter_flush') as HTMLInputElement;
 
+  const convertEolCheckbox =
+      document.getElementById('convert_eol') as HTMLInputElement;
+  const convertEolCheckboxHandler = () => {
+    term.setOption('convertEol', convertEolCheckbox.checked);
+  };
+  convertEolCheckbox.addEventListener('change', convertEolCheckboxHandler);
+  convertEolCheckboxHandler();
+
   const serial = usePolyfill ? polyfill : navigator.serial;
   const ports: (SerialPort | SerialPortPolyfill)[] = await serial.getPorts();
   ports.forEach((port) => addNewPort(port));


### PR DESCRIPTION
Some devices only send a '\n' to indicate an end of line. This option
enables an automatic conversion to a '\r\n' so that the cursor is
returned to the beginning of the line after every line feed.