### PR TITLE
improve layout and styling of options bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,13 @@
       height: 90vh;
     }
     .options {
-      height: 10vh;
-      padding: 15px;
+      padding: 0.75em;
+    }
+    #connect {
+      margin-right: 2em;
+    }
+    label.checkbox {
+      margin-right: 1em;
     }
   </style>
 </head>
@@ -22,9 +27,15 @@
 <div class="options">
   <label for="ports">Port:</label>
   <select id="ports">
-    <option value="prompt">Add a port...</option>
+    <option value="prompt">Click 'Connect' to add a port...</option>
   </select>
   <button id="connect">Connect</button>
+
+  <button id="download">Download output</button>
+  <button id="clear">Clear output</button>
+
+  <br>
+
   <label for="baudrate">Baud rate:</label>
   <select id="baudrate">
     <option value="9600">9600</option>
@@ -58,17 +69,17 @@
   </select>
   <input id="rtscts" type="checkbox">
   <label for="rtscts">Hardware flow control</label>
-  <input id="echo" type="checkbox">
+
   <br>
-  <label for="echo">Local echo</label>
+
+  <input id="echo" type="checkbox">
+  <label class="checkbox" for="echo">Local echo</label>
   <input id="enter_flush" type="checkbox">
-  <label for="enter_flush">Flush on enter</label>
+  <label class="checkbox" for="enter_flush">Flush on enter</label>
   <input id="convert_eol" type="checkbox">
-  <label for="convert_eol">Convert EOL</label>
+  <label class="checkbox" for="convert_eol">Convert EOL</label>
   <input id="autoconnect" type="checkbox">
-  <label for="autoconnect">Automatically connect</label>
-  <button id="download">Download output</button>
-  <button id="clear">Clear output</button>
+  <label class="checkbox" for="autoconnect">Automatically connect</label>
 </div>
 <div id="terminal"></div>
 <script type="module" src="/src/index.ts"></script>


### PR DESCRIPTION
improve layout and styling of options bar - see screenshots below.
* a bit more space between options, move buttons to the top, separate into three lines without taking up more vertical space
* Line2 and Line3 are nicely grouped for hardware options, local behaviour options
* fix checkbox on the wrong line than its label
* include a usability improvement of explicitly calling out to first click Connect to populate the Ports drop-down menu. I observed this issue with multiple novice users who were confused about the empty list.


**Old:**
<img width="900" alt="198360953-82f2a636-1603-4f27-8c36-732222aabb05" src="https://user-images.githubusercontent.com/114300/202200807-6c987dc1-bdb1-4bf2-9f84-1abed027f37a.png">


**New:**
<img width="900" alt="198360957-796a2909-6099-4b1f-803f-1a8c4aeed9ab" src="https://user-images.githubusercontent.com/114300/202200878-4a8b0dfa-2222-493c-9e3b-2bb3163fca74.png">
