### PR TITLE
enable auto-connect by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
   <label class="checkbox" for="enter_flush">Flush on enter</label>
   <input id="convert_eol" type="checkbox">
   <label class="checkbox" for="convert_eol">Convert EOL</label>
-  <input id="autoconnect" type="checkbox">
-  <label class="checkbox" for="autoconnect">Automatically connect</label>
+  <input id="autoconnect" type="checkbox" checked>
+  <label class="checkbox" for="autoconnect">Automatically reconnect</label>
 </div>
 <div id="terminal"></div>
 <script type="module" src="/src/index.ts"></script>


### PR DESCRIPTION
This PR changes the default of the autoconnect feature.
My reasoning: this feature is especially useful when working with devices and prototypes and get reset / rebooted frequently while using the web serial-terminal. Users who want to disconnect, simply click on "Disconnect" as before. Users who want a "continuous" connection to their device will now benefit by default.