### PR TITLE
add link to source code repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     .options {
       padding: 0.75em;
     }
+    .info {
+      float: right;
+    }
     #connect {
       margin-right: 2em;
     }
@@ -80,6 +83,10 @@
   <label class="checkbox" for="convert_eol">Convert EOL</label>
   <input id="autoconnect" type="checkbox">
   <label class="checkbox" for="autoconnect">Automatically connect</label>
+
+  <div class="info">
+    <a href="https://github.com/GoogleChromeLabs/serial-terminal">Source Code on GitHub</a>
+  </div>
 </div>
 <div id="terminal"></div>
 <script type="module" src="/src/index.ts"></script>


### PR DESCRIPTION
This makes it easier to discover the source code. Previously the rendered GitHub Page did not link back to its source code, requiring a bit of guessing or searching for it.

The new link is floating in the header menu bar on the right, where there is plenty of space:
<img width="901" alt="Screenshot 2023-03-19 at 18 17 28" src="https://user-images.githubusercontent.com/114300/226194760-a95b56cc-d3cc-41cb-be6f-5d816495a823.png">
