### PR TITLE
Update to upload-pages-artifact@v3 and deploy-pages@v4

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
         CI: true
     - name: Upload artifacts
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: dist/
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The older versions of these artifact deployment actions are deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/