### PR TITLE
Update Node.js version from 18 to 24

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
     - name: Install NPM packages
       run: npm ci
     - name: Build


### PR DESCRIPTION
Node.js 18 is no longer supported. Node.js 24 is the latest LTS.